### PR TITLE
Fix pressure control client

### DIFF
--- a/ros/kxr_controller/python/kxr_controller/kxr_interface.py
+++ b/ros/kxr_controller/python/kxr_controller/kxr_interface.py
@@ -44,15 +44,18 @@ class KXRROSRobotInterface(ROSRobotInterfaceBase):
         self.stretch_topic_name = namespace \
             + '/kxr_fullbody_controller/stretch'
         # Pressure control client
-        self.pressure_control_client = actionlib.SimpleActionClient(
-            namespace + '/kxr_fullbody_controller/pressure_control_interface',
-            PressureControlAction)
-        self.enabled_pressure_control = True
-        if not self.pressure_control_client.wait_for_server(timeout):
-            rospy.logerr("PressureControl action server not available.")
-            self.enabled_pressure_control = False
-        self.pressure_topic_name_base = namespace \
-            + '/kxr_fullbody_controller/pressure/'
+        pressure_param = namespace + '/rcb4_ros_bridge/control_pressure'
+        self.control_pressure = rospy.get_param(pressure_param, False)
+        if self.control_pressure is True:
+            self.pressure_control_client = actionlib.SimpleActionClient(
+                namespace + '/kxr_fullbody_controller/pressure_control_interface',
+                PressureControlAction)
+            self.enabled_pressure_control = True
+            if not self.pressure_control_client.wait_for_server(timeout):
+                rospy.logerr("PressureControl action server not available.")
+                self.enabled_pressure_control = False
+            self.pressure_topic_name_base = namespace \
+                + '/kxr_fullbody_controller/pressure/'
 
     def servo_on(self, joint_names=None):
         if joint_names is None:

--- a/ros/kxreus/euslisp/kxr-interface.l
+++ b/ros/kxreus/euslisp/kxr-interface.l
@@ -43,7 +43,9 @@
    (let* ((namespace (cadr (memq :namespace args)))
           (c-name (cadr (memq :controller-name args)))
           (joint-param (if namespace (format nil "~A/~A/joints" namespace c-name)
-                           (format nil "/~A/joints" c-name))))
+                         (format nil "/~A/joints" c-name)))
+          (pressure-param (if namespace (format nil "~A/rcb4_ros_bridge/control_pressure" namespace)
+                            (format nil "/rcb4_ros_bridge/control_pressure"))))
      (setq controller-name (cadr (memq :controller-name args)))
      (setq joint-names (ros::get-param joint-param nil))
      (while (and (ros::ok) (null joint-names))
@@ -65,12 +67,15 @@
                                     (format nil "/~A/stretch_interface" controller-name))
                                   kxr_controller::StretchAction
                                   :groupname groupname))
-   (setq pressure-control-client (instance ros::simple-action-client :init
-                                  (if namespace (format nil "/~A/~A/pressure_control_interface" namespace controller-name)
-                                    (format nil "/~A/pressure_control_interface" controller-name))
-                                  kxr_controller::PressureControlAction
-                                  :groupname groupname))
-   (dolist (action (list servo-on-off-client stretch-client pressure-control-client))
+   (setq control-pressure (ros::get-param pressure-param nil))
+   (when control-pressure
+     (setq pressure-control-client (instance ros::simple-action-client :init
+                                             (if namespace (format nil "/~A/~A/pressure_control_interface" namespace controller-name)
+                                               (format nil "/~A/pressure_control_interface" controller-name))
+                                             kxr_controller::PressureControlAction
+                                             :groupname groupname)))
+   (dolist (action (if control-pressure (list servo-on-off-client stretch-client pressure-control-client)
+                     (list servo-on-off-client stretch-client)))
      (unless (and joint-action-enable (send action :wait-for-server 3))
        (setq joint-action-enable nil)
        (ros::ros-warn "~A is not respond, kxr-interface is disabled" action)


### PR DESCRIPTION
This commit avoids printing logerr if user does not intend to run PressureControl action server.